### PR TITLE
fix(docker): remove frontend port 3000 from base compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "3000:3000"
     environment:
       - NEXT_PUBLIC_API_URL=http://backend:8000
     networks:


### PR DESCRIPTION
Port 3000 was conflicting with profile.nuclearbomb6518.com (PM2). Frontend uses port 3200 via windows overlay only.