### PR TITLE
fix: remove empty ports key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 
   frontend:
     build: ./frontend
-    ports:
     environment:
       - NEXT_PUBLIC_API_URL=http://backend:8000
     networks:


### PR DESCRIPTION
Removes leftover empty ports: key from frontend service causing docker compose validation error.