### PR TITLE
fix(auth): replace passlib with bcrypt directly

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -3,27 +3,25 @@ import io
 import secrets
 from datetime import datetime, timedelta, timezone
 
+import bcrypt
 import pyotp
 import qrcode
 from jose import jwt
-from passlib.context import CryptContext
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import Settings
 from ..models.user import User, UserRole, RefreshToken
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 MAX_LOGIN_FAILURES = 5
 
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt(12)).decode()
 
 
 def verify_password(plain: str, hashed: str) -> bool:
-    return pwd_context.verify(plain, hashed)
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
 def create_access_token(user_id: int, settings: Settings) -> str:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,7 @@ alembic==1.13.0
 pydantic[email]==2.8.0
 pydantic-settings==2.4.0
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
+bcrypt==5.0.0
 pyotp==2.9.0
 cryptography==43.0.0
 python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- `passlib 1.7.4` + `bcrypt 5.0.0` 버전 충돌로 로그인 전체 불가 상태였음
- passlib이 bcrypt 4.x 이후 제거된 `__about__.__version__` 속성을 참조해서 `verify_password`가 항상 예외 발생
- `CryptContext` 제거하고 `bcrypt.hashpw` / `bcrypt.checkpw` 직접 호출로 교체

## Test plan
- [ ] 로그인 시도: `admin@kis-trader.local` / `KisAdmin2026`
- [ ] 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)