### PR TITLE
fix(frontend): pass NEXT_PUBLIC_API_URL as build arg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,12 @@ services:
     restart: unless-stopped
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        NEXT_PUBLIC_API_URL: https://trader-api.nuclearbomb6518.com
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8000
+      - NEXT_PUBLIC_API_URL=https://trader-api.nuclearbomb6518.com
     networks:
       - external
     restart: unless-stopped

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22-alpine AS builder
 
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_*` 변수는 Next.js 빌드 타임에 번들에 인라인됨 — 런타임 `environment`만으로는 적용 안 됨
- Dockerfile에 `ARG NEXT_PUBLIC_API_URL` + `ENV` 추가
- docker-compose `build.args`로 `https://trader-api.nuclearbomb6518.com` 전달

## Test plan
- [ ] 배포 후 로그인 페이지에서 `admin@nuclearbomb6518.com` / `xmfpdleldAdmin!` 로그인 확인
- [ ] 브라우저 네트워크 탭에서 요청이 `https://trader-api.nuclearbomb6518.com`으로 가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)